### PR TITLE
:wrench: Add a dependabot file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "docker" 
+    directory: "/docker" 
+    schedule:
+      interval: "weekly"
+    labels:
+      - "⬆️ up-to-date"


### PR DESCRIPTION
Hello @pawlean , I initiate a dependabot configuration file. I can't test but I inspired myself from Zenika project I already used.

With this file, we (hope) to see PR each weekly which detects if new version of Java Docker image is available. Like that we can creates releases for each new version. So we can now create a release for the Java version defined actually in the Dockerfile, ie java-17. To follow semantic release, we can create a v1.0.0 version for the Java 17 version ?